### PR TITLE
Add CodeGRITS Status Bar Widget and its factory implementation

### DIFF
--- a/src/main/java/components/statusbar/CodeGRITSStatusWidget.java
+++ b/src/main/java/components/statusbar/CodeGRITSStatusWidget.java
@@ -1,0 +1,73 @@
+package components.statusbar;
+
+import com.intellij.openapi.wm.StatusBar;
+import com.intellij.openapi.wm.StatusBarWidget;
+import com.intellij.util.Consumer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.awt.*;
+import java.awt.event.MouseEvent;
+
+/**
+ * Status Bar Widget for CodeGRITS.
+ * Displays the current tracking state (default = "Stopped").
+ */
+public class CodeGRITSStatusWidget implements StatusBarWidget, StatusBarWidget.TextPresentation {
+
+    private static final String WIDGET_ID = "CodeGRITSStatusWidget";
+
+    // Default state shown on startup
+    private String text = "CodeGRITS: Stopped";
+
+    @Override
+    public @NotNull String ID() {
+        return WIDGET_ID;
+    }
+
+    @Override
+    public void install(@NotNull StatusBar statusBar) {
+        // No special initialization yet
+    }
+
+    @Override
+    public void dispose() {
+        // Nothing to dispose yet
+    }
+
+    @Override
+    public @Nullable WidgetPresentation getPresentation() {
+        return this; // We implement TextPresentation ourselves
+    }
+
+    // ===== WidgetPresentation / TextPresentation =====
+
+    @Override
+    public @Nullable String getTooltipText() {
+        return "CodeGRITS Tracking Status";
+    }
+
+    @Override
+    public @Nullable Consumer<MouseEvent> getClickConsumer() {
+        // No click action yet – can add later
+        return null;
+    }
+
+    @Override
+    public @NotNull String getText() {
+        return text;
+    }
+
+    @Override
+    public float getAlignment() {
+        return Component.CENTER_ALIGNMENT;
+    }
+
+    /**
+     * Allows other parts of the plugin (e.g., Start/Stop tracking)
+     * to update the status text.
+     */
+    public void setState(@NotNull String newState) {
+        this.text = "CodeGRITS: " + newState;
+    }
+}

--- a/src/main/java/components/statusbar/CodeGRITSStatusWidgetFactory.java
+++ b/src/main/java/components/statusbar/CodeGRITSStatusWidgetFactory.java
@@ -1,0 +1,48 @@
+package components.statusbar;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.StatusBar;
+import com.intellij.openapi.wm.StatusBarWidget;
+import com.intellij.openapi.wm.StatusBarWidgetFactory;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Factory that registers and creates the CodeGRITS Status Bar Widget.
+ */
+public class CodeGRITSStatusWidgetFactory implements StatusBarWidgetFactory {
+
+    @Override
+    public @NotNull String getId() {
+        return "CodeGRITSStatusWidget"; // MUST remain stable forever
+    }
+
+    @Override
+    public @NotNull String getDisplayName() {
+        return "CodeGRITS Tracking Status";
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull Project project) {
+        return true; // Always available
+    }
+
+    @Override
+    public boolean isEnabledByDefault() {
+        return true; // <-- THIS FIXES YOUR BUG
+    }
+
+    @Override
+    public @NotNull StatusBarWidget createWidget(@NotNull Project project) {
+        return new CodeGRITSStatusWidget();
+    }
+
+    @Override
+    public void disposeWidget(@NotNull StatusBarWidget widget) {
+        widget.dispose();
+    }
+
+    @Override
+    public boolean canBeEnabledOn(@NotNull StatusBar statusBar) {
+        return true;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -37,6 +37,9 @@
         <projectService serviceImplementation="api.RealtimeDataImpl"/>
         <notificationGroup id="CodeGRITS Notification Group"
                            displayType="BALLOON"/>
+                           <!-- CodeGRITS Status Bar Widget -->
+        <statusBarWidgetFactory
+            implementation="components.statusbar.CodeGRITSStatusWidgetFactory"/>
     </extensions>
 
     <actions>


### PR DESCRIPTION
Implement CodeGRITS Status Bar Widget

This PR introduces the initial CodeGRITS status bar widget. The widget now loads automatically when the IDE starts and displays a clear default “Stopped” state before tracking begins. This completes the requirements for Issue #3 .

Acceptance Criteria Met

Widget appears on startup without requiring manual activation

Default state (“Stopped”) is clearly visible

No errors or warnings during IDE load

Fully integrated with the status bar widget factory

Closes: #3 